### PR TITLE
feat: Display test262 metrics as a stacked area chart

### DIFF
--- a/pages/test262.css
+++ b/pages/test262.css
@@ -1,16 +1,3 @@
 .chart {
   height: 100%;
 }
-
-.chart * {
-  font-family: var(--font-mono);
-  font-variant: tabular-nums;
-}
-
-.chart tspan {
-  fill: var(--neutral-800);
-}
-
-.chart tspan[x="0"] {
-  font-size: 10px;
-}

--- a/pages/test262.tsx
+++ b/pages/test262.tsx
@@ -37,9 +37,7 @@ function dataset(datapoints: typeof data, result: keyof Metrics["results"]) {
   };
 }
 
-const octokit = new Octokit({
-  auth: "130142cd1b8189111d726b4691d9b0fd43d9da0f",
-});
+const octokit = new Octokit();
 const commits = await octokit.rest.repos.listCommits({
   owner: "trynova",
   repo: "nova",

--- a/pages/test262.tsx
+++ b/pages/test262.tsx
@@ -12,33 +12,54 @@ import { Layout } from "components/Layout.tsx";
 
 const classes = await css(import.meta.resolve("./test262.css"));
 
-const octokit = new Octokit();
+interface Metrics {
+  results: {
+    crash: number;
+    fail: number;
+    pass: number;
+    skip: number;
+    timeout: number;
+    unresolved: number;
+  };
+  total: number;
+}
 
+function dataset(datapoints: typeof data, result: keyof Metrics["results"]) {
+  return {
+    label: result[0].toUpperCase() + result.slice(1),
+    data: datapoints.map(({ metrics: { total, results } }) =>
+      results[result] / total * 100
+    ),
+    backgroundColor: `var(--chart-${result})`,
+    borderColor: `var(--chart-${result})`,
+    fill: "origin",
+    pointStyle: false,
+  };
+}
+
+const octokit = new Octokit({
+  auth: "130142cd1b8189111d726b4691d9b0fd43d9da0f",
+});
 const commits = await octokit.rest.repos.listCommits({
   owner: "trynova",
   repo: "nova",
-  path: "tests/expectations.json",
+  path: "tests/metrics.json",
   per_page: 100,
 });
 
 const data = (await Promise.all(commits.data.map(async (commit) => {
-  const expectations = await (await fetch(
-    `https://raw.githubusercontent.com/trynova/nova/${commit.sha}/tests/expectations.json`,
-  )).json() as Record<string, "PASS" | "FAIL" | "CRASH" | "TIMEOUT">;
-  const results = Object.values(expectations);
+  const metrics = await (await fetch(
+    `https://raw.githubusercontent.com/trynova/nova/${commit.sha}/tests/metrics.json`,
+  )).json() as Metrics;
   return {
     sha: commit.sha,
     message: commit.commit.message,
     date: Temporal.Instant.from(commit.commit.author?.date),
-    expectations,
-    metrics: {
-      pass: results.filter((result) => result === "PASS").length,
-      fail: results.filter((result) => result === "FAIL").length,
-      crash: results.filter((result) => result === "CRASH").length,
-      timeout: results.filter((result) => result === "TIMEOUT").length,
-    },
+    metrics,
   };
 }))).sort(({ date: a }, { date: b }) => Temporal.Instant.compare(a, b));
+
+if (data.length === 1) data.push(data[0]);
 
 function Test262() {
   return (
@@ -55,13 +76,45 @@ function Test262() {
         type="line"
         svgClass={classes.chart}
         options={{
+          plugins: {
+            filler: {
+              propagate: false,
+            },
+            legend: {
+              labels: {
+                color: "var(--neutral-800)",
+                font: {
+                  family: "var(--font-mono)",
+                  size: 10,
+                },
+                padding: 16,
+              },
+            },
+          },
           scales: {
             x: {
+              ticks: {
+                color: "var(--neutral-800)",
+                font: {
+                  family: "var(--font-mono)",
+                  size: 10,
+                },
+              },
               grid: {
                 color: "var(--neutral-400)",
               },
             },
             y: {
+              stacked: true,
+              min: 0,
+              max: 100,
+              ticks: {
+                color: "var(--neutral-800)",
+                font: {
+                  family: "var(--font-mono)",
+                  size: 10,
+                },
+              },
               grid: {
                 color: "var(--neutral-400)",
               },
@@ -71,31 +124,12 @@ function Test262() {
         data={{
           labels: data.map(({ sha }) => sha.slice(0, 7)),
           datasets: [
-            // {
-            //   label: "Pass",
-            //   data: data.map(({ metrics }) => metrics.pass),
-            //   borderColor: "var(--success)",
-            //   pointStyle: false,
-            // },
-            {
-              label: "Fail",
-              data: data.map(({ metrics }) => metrics.fail),
-              borderColor: "var(--error)",
-              pointStyle: false,
-            },
-            {
-              label: "Crash",
-              data: data.map(({ metrics }) => metrics.crash),
-              borderColor: "var(--error)",
-              borderDash: [5, 5],
-              pointStyle: false,
-            },
-            {
-              label: "Timeout",
-              data: data.map(({ metrics }) => metrics.timeout),
-              borderColor: "var(--warning)",
-              pointStyle: false,
-            },
+            dataset(data, "pass"),
+            dataset(data, "skip"),
+            dataset(data, "timeout"),
+            dataset(data, "unresolved"),
+            dataset(data, "fail"),
+            dataset(data, "crash"),
           ],
         }}
       />
@@ -113,9 +147,4 @@ if (import.meta.main) {
     output(import.meta.url),
     html(renderToString(<Test262 />), { title: "Test262 · Nova" }),
   );
-
-  // HACK: Exit process to prevent hanging. There is a bug loose in the code
-  // preventing the process from exiting. Probably a promise that is not being
-  // awaited or octokit which needs to be closed somehow.
-  Deno.exit();
 }

--- a/public/variables.css
+++ b/public/variables.css
@@ -33,9 +33,12 @@
     --accent-900: #48426d;
     --accent-950: #27233a;
 
-    --success: #2e854b;
-    --warning: #d9a620;
-    --error: #b52b2b;
+    --chart-pass: #2e854b;
+    --chart-fail: #b52b2b;
+    --chart-crash: #821d1d;
+    --chart-skip: #d9a620;
+    --chart-timeout: #d9a620;
+    --chart-unresolved: #d9a620;
 
     --selection-color: var(--neutral-950);
 


### PR DESCRIPTION
![bild](https://github.com/user-attachments/assets/c96193e7-75e7-4bc5-84c0-64806cd74448)

We might want to wait a bit until we have some history on the [`metrics.json`](https://github.com/trynova/nova/blob/main/tests/metrics.json) file so the chart doesn't look so bare.